### PR TITLE
use path.join()

### DIFF
--- a/lib/control-file.js
+++ b/lib/control-file.js
@@ -4,6 +4,7 @@ import {shallowCopyTargetProperty, unicodeEscapeSequenceToChar, toArrayBuffer, t
 
 import fs from 'fs';
 import cson from 'cson';
+import path from 'path';
 
 /*
 class
@@ -59,35 +60,35 @@ export class ImpulseResponse {
 /*
 export read
 */
-export function readSource(path, dataPath) {
-  return readConfigFile(path, dataPath, stringToSourceFile);
+export function readSource(filePath, dataPath) {
+  return readConfigFile(filePath, dataPath, stringToSourceFile);
 }
-export function getReadSource(path, dataPath) {
+export function getReadSource(filePath, dataPath) {
   return () => {
-    return readSource(path, dataPath);
+    return readSource(filePath, dataPath);
   }
 }
 
-export function readIR(path, dataPath) {
-  return readConfigFile(path, dataPath, stringToIR);
+export function readIR(filePath, dataPath) {
+  return readConfigFile(filePath, dataPath, stringToIR);
 }
-export function getReadIR(path, dataPath) {
+export function getReadIR(filePath, dataPath) {
   return () => {
-    return readIR(path, dataPath);
+    return readIR(filePath, dataPath);
   }
 }
 
-export function readKeyBind(path) {
-  if(path === null) {
+export function readKeyBind(filePath) {
+  if(filePath === null) {
     return null;
   }
-  return createReadFilePromise(path, null, stringToKeyBind);
+  return createReadFilePromise(filePath, null, stringToKeyBind);
 }
 
 //
-function createReadFilePromise(path, dataPath, converter) {
+function createReadFilePromise(filePath, dataPath, converter) {
   return new Promise ( (resolve, reject)=> {
-    fs.readFile(path, 'utf-8', (err, data) => {
+    fs.readFile(filePath, 'utf-8', (err, data) => {
       if(err) {
         reject([err, 0]);
         return;
@@ -103,11 +104,11 @@ function createReadFilePromise(path, dataPath, converter) {
 }
 
 //
-function readConfigFile(path, dataPath, converter) {
-  if(path === null) {
+function readConfigFile(filePath, dataPath, converter) {
+  if(filePath === null) {
     return null;
   }
-  let promise = createReadFilePromise(path, dataPath, converter);
+  let promise = createReadFilePromise(filePath, dataPath, converter);
   return promise.then(readBinaryDatas); //返るのは、readBinaryDatasのpromise
 }
 
@@ -164,7 +165,7 @@ function stringToKeyBind(data) {
   return keyBinds;
 }
 
-function stringToSourceFile(data, path) {
+function stringToSourceFile(data, commonPath) {
   let obj = cson.parse(unicodeEscapeSequenceToChar(data));
 
   if(obj instanceof Error) {
@@ -175,7 +176,7 @@ function stringToSourceFile(data, path) {
     return new Error(`file is invalid.`);
   }
   if(obj.commonPath === '') {
-    obj.commonPath = path;
+    obj.commonPath = commonPath;
   }
 
   let sourceFiles = [];
@@ -192,13 +193,13 @@ function stringToSourceFile(data, path) {
     if(sourceFile.name === '') {
       sourceFile.name = sourceFile.fileName;
     }
-    sourceFile.fileName = obj.commonPath + '\\' + sourceFile.fileName
+    sourceFile.fileName = path.join(obj.commonPath, sourceFile.fileName);
     sourceFiles.push(sourceFile);
   }
   return sourceFiles;
 }
 
-function stringToIR(data, path) {
+function stringToIR(data, commonPath) {
   let obj = cson.parse(unicodeEscapeSequenceToChar(data));
 
   if(obj instanceof Error) {
@@ -209,7 +210,7 @@ function stringToIR(data, path) {
     return new Error(`file is invalid.`);
   }
   if(obj.commonPath === '') {
-    obj.commonPath = path;
+    obj.commonPath = commonPath;
   }
 
   let impulseResponses = [];
@@ -223,7 +224,7 @@ function stringToIR(data, path) {
     ) {
       return new Error(`${i}th data is invalid.` + impulseResponse.toString());
     }
-    impulseResponse.fileName = obj.commonPath + '\\' + impulseResponse.fileName
+    impulseResponse.fileName = path.join(obj.commonPath, impulseResponse.fileName);
     impulseResponses.push(impulseResponse);
   }
   return impulseResponses;
@@ -233,46 +234,46 @@ function stringToIR(data, path) {
 export output
 */
 
-export function writeToCson(path, obj, resolved, rejected) {
+export function writeToCson(filePath, obj, resolved, rejected) {
   let data = cson.createCSONString(obj, {indent: "  "});
   let promise = new Promise( (resolve, reject) => {
-    fs.writeFile(path, data, (err) => {
+    fs.writeFile(filePath, data, (err) => {
       if(err) {
         reject(err);
         return
       }
-      resolve(path);
+      resolve(filePath);
     });
   });
   promise.then(resolved, rejected);
 }
 
-export function writeAnalysedData(path, data, resolved, rejected) {
+export function writeAnalysedData(filePath, data, resolved, rejected) {
   let writeString = '';
   for(let i = 0; i < data.length; ++i) {
     writeString += data[i].toString(10) + '\n';
   }
   let promise = new Promise( (resolve, reject) => {
-    fs.writeFile(path, writeString, (err) => {
+    fs.writeFile(filePath, writeString, (err) => {
       if(err) {
         reject(err);
         return
       }
-      resolve(path);
+      resolve(filePath);
     });
   });
   promise.then(resolved, rejected);
 }
 
-export function writeBinaryData(path, data) {
+export function writeBinaryData(filePath, data) {
   let buf = toBuffer(data);
   let promise = new Promise( (resolve, reject) => {
-    fs.writeFile(path, buf, (err) => {
+    fs.writeFile(filePath, buf, (err) => {
       if(err) {
         reject(err);
         return
       }
-      resolve(path);
+      resolve(filePath);
     });
   });
   return promise;


### PR DESCRIPTION
This will join paths on any platform, not just Windows. I decided to import the `path` module as one would expect, so I had to rename all variables `path` to something else.